### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "vue": "^3.5.12",
         "vue-loader": "^17.4.2",
         "xlsx": "^0.18.5",
-        "zoom-vanilla.js": "^2.0.6"
+        "zoom-vanilla.js": "^2.0.6",
+        "sanitize-html": "^2.14.0"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",

--- a/resources/js/themes/tinker.js
+++ b/resources/js/themes/tinker.js
@@ -1,3 +1,5 @@
+const sanitizeHtml = require("sanitize-html");
+
 (function () {
     "use strict";
 
@@ -36,11 +38,9 @@
     const initTooltips = (function tooltips() {
         $(".side-menu").each(function () {
             if (this._tippy == undefined) {
-                const content = $(this)
-                    .find(".side-menu__title")
-                    .html()
-                    .replace(/<[^>]*>?/gm, "")
-                    .trim();
+                const content = sanitizeHtml(
+                    $(this).find(".side-menu__title").html().trim()
+                );
                 tippy(this, {
                     content: content,
                     arrow: roundArrow,


### PR DESCRIPTION
Potential fix for [https://github.com/shahrilazwa/digital-services-survey/security/code-scanning/6](https://github.com/shahrilazwa/digital-services-survey/security/code-scanning/6)

To fix the issue, we should use a well-tested sanitization library that can handle various edge cases and ensure effective removal of unsafe HTML content. The `sanitize-html` library is a popular choice for this purpose. It allows us to remove unsafe tags and attributes while keeping the safe ones.

We will replace the current regular expression-based sanitization with the `sanitize-html` library. This change will involve importing the library and using it to sanitize the content before it is used in the tooltip.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
